### PR TITLE
Separate line name from number and color

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -1,146 +1,146 @@
-name, line
-"Tucuruvi",Linha 1–Azul
-"Parada Inglesa",Linha 1–Azul
-"Jardim São Paulo-Ayrton Senna",Linha 1–Azul 
-"Santana", Linha 1–Azul
-"Carandiru", Linha 1–Azul
-"Portuguesa-Tietê", Linha 1–Azul
-"Armênia", Linha 1–Azul
-"Tiradentes", Linha 1–Azul
-"Luz", Linha 1–Azul
-"São Bento", Linha 1–Azul
-"Sé", Linha 1–Azul
-"Japão-Liberdade", Linha 1–Azul
-"São Joaquim", Linha 1–Azul
-"Vergueiro", Linha 1–Azul
-"Paraíso", Linha 1–Azul
-"Ana Rosa", Linha 1–Azul
-"Vila Mariana", Linha 1–Azul
-"Santa Cruz", Linha 1–Azul
-"Praça da Árvore", Linha 1–Azul
-"Saúde", Linha 1–Azul
-"São Judas", Linha 1–Azul
-"Conceição", Linha 1–Azul
-"Jabaquara", Linha 1–Azul
-"Vila Madalena", Linha 2–Verde
-"Santuário Nossa Senhora de Fátima-Sumaré", Linha 2–Verde
-"Clínicas", Linha 2–Verde
-"Consolação", Linha 2–Verde
-"Trianon-Masp", Linha 2–Verde
-"Brigadeiro", Linha 2–Verde
-"Paraíso", Linha 2–Verde
-"Ana Rosa", Linha 2–Verde
-"Chácara Klabin", Linha 2–Verde
-"Santos-Imigrantes", Linha 2–Verde
-"Alto do Ipiranga", Linha 2–Verde
-"Sacomã", Linha 2–Verde
-"Tamanduateí", Linha 2–Verde
-"Vila Prudente · Orfanato", Linha 2–Verde
-"Água Rasa", Linha 2–Verde
-"Anália Franco", Linha 2–Verde
-"Vila Formosa", Linha 2–Verde
-"Guilherme Giorgi", Linha 2–Verde
-"Nova Manchester", Linha 2–Verde
-"Aricanduva", Linha 2–Verde
-"Penha", Linha 2–Verde
-"Penha de França", Linha 2–Verde
-"Tiquatira", Linha 2–Verde
-"Paulo Freire", Linha 2–Verde
-"Ponte Grande", Linha 2–Verde
-"Dutra", Linha 2–Verde
-"Palmeiras-Barra Funda", Linha 3–Vermelha
-"Marechal Deodoro", Linha 3–Vermelha
-"Santa Cecília", Linha 3–Vermelha
-"República", Linha 3–Vermelha
-"Anhangabaú", Linha 3–Vermelha
-"Sé", Linha 3–Vermelha
-"Pedro II", Linha 3–Vermelha
-"Brás", Linha 3–Vermelha
-"Bresser-Mooca", Linha 3–Vermelha
-"Belém", Linha 3–Vermelha
-"Tatuapé", Linha 3–Vermelha
-"Carrão", Linha 3–Vermelha
-"Penha", Linha 3–Vermelha
-"Vila Matilde", Linha 3–Vermelha
-"Guilhermina-Esperança", Linha 3–Vermelha
-"Patriarca", Linha 3–Vermelha
-"Artur Alvim", Linha 3–Vermelha
-"Corinthians-Itaquera", Linha 3–Vermelha
-"Vila Sônia", Linha 4–Amarela
-"São Paulo-Morumbi", Linha 4–Amarela
-"Butantã", Linha 4–Amarela
-"Pinheiros", Linha 4–Amarela
-"Faria Lima", Linha 4–Amarela
-"Fradique Coutinho", Linha 4–Amarela
-"Oscar Freire", Linha 4–Amarela
-"Paulista", Linha 4–Amarela
-"Higienópolis-Mackenzie", Linha 4–Amarela
-"República", Linha 4–Amarela
-"Luz", Linha 4–Amarela
-"Capão Redondo", Linha 5–Lilás
-"Campo Limpo", Linha 5–Lilás
-"Vila das Belezas", Linha 5–Lilás
-"Giovanni Gronchi", Linha 5–Lilás
-"Santo Amaro", Linha 5–Lilás
-"Largo Treze", Linha 5–Lilás
-"Adolfo Pinheiro", Linha 5–Lilás
-"Alto da Boa Vista", Linha 5–Lilás
-"Borba Gato", Linha 5–Lilás
-"Brooklin", Linha 5–Lilás
-"Campo Belo", Linha 5–Lilás
-"Eucaliptos", Linha 5–Lilás
-"Moema", Linha 5–Lilás
-"AACD-Servidor", Linha 5–Lilás
-"Hospital São Paulo", Linha 5–Lilás
-"Santa Cruz", Linha 5–Lilás
-"Chácara Klabin", Linha 5–Lilás
-"Brasilândia", Linha 6–Laranja
-"Vila Cardoso", Linha 6–Laranja
-"Itaberaba", Linha 6–Laranja
-"João Paulo I", Linha 6–Laranja
-"Freguesia do Ó", Linha 6–Laranja
-"Santa Marina", Linha 6–Laranja
-"Água Branca", Linha 6–Laranja
-"SESC-Pompéia", Linha 6–Laranja
-"Perdizes", Linha 6–Laranja
-"PUC-Cardoso de Almeida", Linha 6–Laranja
-"Angélica-Pacaembu", Linha 6–Laranja
-"Higienópolis-Mackenzie", Linha 6–Laranja
-"14 Bis", Linha 6–Laranja
-"Bela Vista", Linha 6–Laranja
-"São Joaquim", Linha 6–Laranja
-"Ipiranga", Linha 15–Prata
-"Vila Prudente", Linha 15–Prata
-"Oratório", Linha 15–Prata
-"São Lucas", Linha 15–Prata
-"Camilo Haddad", Linha 15–Prata
-"Vila Tolstói", Linha 15–Prata
-"Vila União", Linha 15–Prata
-"Jardim Planalto", Linha 15–Prata
-"Sapopemba", Linha 15–Prata
-"Fazenda da Juta", Linha 15–Prata
-"São Mateu", Linha 15–Prata
-"Iguatemi", Linha 15–Prata
-"Jequiriçá", Linha 15–Prata
-"Jacú-Pêssego", Linha 15–Prata
-"Érico Semer", Linha 15–Prata
-"Márcio Beck", Linha 15–Prata
-"Cidade Tiradentes", Linha 15–Prata
-"Hospital Cidade Tiradentes", Linha 15–Prata
-"São Paulo-Morumbi", Linha 17–Ouro
-"Estádio Morumbi", Linha 17–Ouro
-"Américo Mourano", Linha 17–Ouro
-"Paraisópolis", Linha 17–Ouro
-"Panamby", Linha 17–Ouro
-"Morumbi", Linha 17–Ouro
-"Chucri Zaidan", Linha 17–Ouro
-"Vila Cordeiro", Linha 17–Ouro
-"Campo Belo", Linha 17–Ouro
-"Vereador José Diniz", Linha 17–Ouro
-"Brooklin Paulista", Linha 17–Ouro
-"Congonhas · Jardim Aeroporto", Linha 17–Ouro
-"Vila Paulista", Linha 17–Ouro
-"Vila Babilônia", Linha 17–Ouro
-"Cidade Leonor", Linha 17–Ouro
-"Hospital Sabóia", Linha 17–Ouro
-"Jabaquara", Linha 17–Ouro
+station_name, line_name, line_number, line_color
+"Tucuruvi",Linha 1-Azul,1, Azul
+"Parada Inglesa",Linha 1-Azul,1, Azul
+"Jardim São Paulo-Ayrton Senna",Linha 1-Azul,1, Azul
+"Santana", Linha 1-Azul,1, Azul
+"Carandiru", Linha 1-Azul,1, Azul
+"Portuguesa-Tietê", Linha 1-Azul,1, Azul
+"Armênia", Linha 1-Azul,1, Azul
+"Tiradentes", Linha 1-Azul,1, Azul
+"Luz", Linha 1-Azul,1, Azul
+"São Bento", Linha 1-Azul,1, Azul
+"Sé", Linha 1-Azul,1, Azul
+"Japão-Liberdade", Linha 1-Azul,1, Azul
+"São Joaquim", Linha 1-Azul,1, Azul
+"Vergueiro", Linha 1-Azul,1, Azul
+"Paraíso", Linha 1-Azul,1, Azul
+"Ana Rosa", Linha 1-Azul,1, Azul
+"Vila Mariana", Linha 1-Azul,1, Azul
+"Santa Cruz", Linha 1-Azul,1, Azul
+"Praça da Árvore", Linha 1-Azul,1, Azul
+"Saúde", Linha 1-Azul,1, Azul
+"São Judas", Linha 1-Azul,1, Azul
+"Conceição", Linha 1-Azul,1, Azul
+"Jabaquara", Linha 1-Azul,1, Azul
+"Vila Madalena", Linha 2-Verde, 2, Verde
+"Santuário Nossa Senhora de Fátima-Sumaré", Linha 2-Verde, 2, Verde
+"Clínicas", Linha 2-Verde, 2, Verde
+"Consolação", Linha 2-Verde, 2, Verde
+"Trianon-Masp", Linha 2-Verde, 2, Verde
+"Brigadeiro", Linha 2-Verde, 2, Verde
+"Paraíso", Linha 2-Verde, 2, Verde
+"Ana Rosa", Linha 2-Verde, 2, Verde
+"Chácara Klabin", Linha 2-Verde, 2, Verde
+"Santos-Imigrantes", Linha 2-Verde, 2, Verde
+"Alto do Ipiranga", Linha 2-Verde, 2, Verde
+"Sacomã", Linha 2-Verde, 2, Verde
+"Tamanduateí", Linha 2-Verde, 2, Verde
+"Vila Prudente · Orfanato", Linha 2-Verde, 2, Verde
+"Água Rasa", Linha 2-Verde, 2, Verde
+"Anália Franco", Linha 2-Verde, 2, Verde
+"Vila Formosa", Linha 2-Verde, 2, Verde
+"Guilherme Giorgi", Linha 2-Verde, 2, Verde
+"Nova Manchester", Linha 2-Verde, 2, Verde
+"Aricanduva", Linha 2-Verde, 2, Verde
+"Penha", Linha 2-Verde, 2, Verde
+"Penha de França", Linha 2-Verde, 2, Verde
+"Tiquatira", Linha 2-Verde, 2, Verde
+"Paulo Freire", Linha 2-Verde, 2, Verde
+"Ponte Grande", Linha 2-Verde, 2, Verde
+"Dutra", Linha 2-Verde, 2, Verde
+"Palmeiras-Barra Funda", Linha 3-Vermelha, 3, Vermelha
+"Marechal Deodoro", Linha 3-Vermelha, 3, Vermelha
+"Santa Cecília", Linha 3-Vermelha, 3, Vermelha
+"República", Linha 3-Vermelha, 3, Vermelha
+"Anhangabaú", Linha 3-Vermelha, 3, Vermelha
+"Sé", Linha 3-Vermelha, 3, Vermelha
+"Pedro II", Linha 3-Vermelha, 3, Vermelha
+"Brás", Linha 3-Vermelha, 3, Vermelha
+"Bresser-Mooca", Linha 3-Vermelha, 3, Vermelha
+"Belém", Linha 3-Vermelha, 3, Vermelha
+"Tatuapé", Linha 3-Vermelha, 3, Vermelha
+"Carrão", Linha 3-Vermelha, 3, Vermelha
+"Penha", Linha 3-Vermelha, 3, Vermelha
+"Vila Matilde", Linha 3-Vermelha, 3, Vermelha
+"Guilhermina-Esperança", Linha 3-Vermelha, 3, Vermelha
+"Patriarca", Linha 3-Vermelha, 3, Vermelha
+"Artur Alvim", Linha 3-Vermelha, 3, Vermelha
+"Corinthians-Itaquera", Linha 3-Vermelha, 3, Vermelha
+"Vila Sônia", Linha 4-Amarela, 4, Amarela
+"São Paulo-Morumbi", Linha 4-Amarela, 4, Amarela
+"Butantã", Linha 4-Amarela, 4, Amarela
+"Pinheiros", Linha 4-Amarela, 4, Amarela
+"Faria Lima", Linha 4-Amarela, 4, Amarela
+"Fradique Coutinho", Linha 4-Amarela, 4, Amarela
+"Oscar Freire", Linha 4-Amarela, 4, Amarela
+"Paulista", Linha 4-Amarela, 4, Amarela
+"Higienópolis-Mackenzie", Linha 4-Amarela, 4, Amarela
+"República", Linha 4-Amarela, 4, Amarela
+"Luz", Linha 4-Amarela, 4, Amarela
+"Capão Redondo", Linha 5-Lilás, 5, Lilás
+"Campo Limpo", Linha 5-Lilás, 5, Lilás
+"Vila das Belezas", Linha 5-Lilás, 5, Lilás
+"Giovanni Gronchi", Linha 5-Lilás, 5, Lilás
+"Santo Amaro", Linha 5-Lilás, 5, Lilás
+"Largo Treze", Linha 5-Lilás, 5, Lilás
+"Adolfo Pinheiro", Linha 5-Lilás, 5, Lilás
+"Alto da Boa Vista", Linha 5-Lilás, 5, Lilás
+"Borba Gato", Linha 5-Lilás, 5, Lilás
+"Brooklin", Linha 5-Lilás, 5, Lilás
+"Campo Belo", Linha 5-Lilás, 5, Lilás
+"Eucaliptos", Linha 5-Lilás, 5, Lilás
+"Moema", Linha 5-Lilás, 5, Lilás
+"AACD-Servidor", Linha 5-Lilás, 5, Lilás
+"Hospital São Paulo", Linha 5-Lilás, 5, Lilás
+"Santa Cruz", Linha 5-Lilás, 5, Lilás
+"Chácara Klabin", Linha 5-Lilás, 5, Lilás
+"Brasilândia", Linha 6-Laranja, 6, Laranja
+"Vila Cardoso", Linha 6-Laranja, 6, Laranja
+"Itaberaba", Linha 6-Laranja, 6, Laranja
+"João Paulo I", Linha 6-Laranja, 6, Laranja
+"Freguesia do Ó", Linha 6-Laranja, 6, Laranja
+"Santa Marina", Linha 6-Laranja, 6, Laranja
+"Água Branca", Linha 6-Laranja, 6, Laranja
+"SESC-Pompéia", Linha 6-Laranja, 6, Laranja
+"Perdizes", Linha 6-Laranja, 6, Laranja
+"PUC-Cardoso de Almeida", Linha 6-Laranja, 6, Laranja
+"Angélica-Pacaembu", Linha 6-Laranja, 6, Laranja
+"Higienópolis-Mackenzie", Linha 6-Laranja, 6, Laranja
+"14 Bis", Linha 6-Laranja, 6, Laranja
+"Bela Vista", Linha 6-Laranja, 6, Laranja
+"São Joaquim", Linha 6-Laranja, 6, Laranja
+"Ipiranga", Linha 15-Prata, 15, Prata
+"Vila Prudente", Linha 15-Prata, 15, Prata
+"Oratório", Linha 15-Prata, 15, Prata
+"São Lucas", Linha 15-Prata, 15, Prata
+"Camilo Haddad", Linha 15-Prata, 15, Prata
+"Vila Tolstói", Linha 15-Prata, 15, Prata
+"Vila União", Linha 15-Prata, 15, Prata
+"Jardim Planalto", Linha 15-Prata, 15, Prata
+"Sapopemba", Linha 15-Prata, 15, Prata
+"Fazenda da Juta", Linha 15-Prata, 15, Prata
+"São Mateu", Linha 15-Prata, 15, Prata
+"Iguatemi", Linha 15-Prata, 15, Prata
+"Jequiriçá", Linha 15-Prata, 15, Prata
+"Jacú-Pêssego", Linha 15-Prata, 15, Prata
+"Érico Semer", Linha 15-Prata, 15, Prata
+"Márcio Beck", Linha 15-Prata, 15, Prata
+"Cidade Tiradentes", Linha 15-Prata, 15, Prata
+"Hospital Cidade Tiradentes", Linha 15-Prata, 15, Prata
+"São Paulo-Morumbi", Linha 17-Ouro, 17, Ouro
+"Estádio Morumbi", Linha 17-Ouro, 17, Ouro
+"Américo Mourano", Linha 17-Ouro, 17, Ouro
+"Paraisópolis", Linha 17-Ouro, 17, Ouro
+"Panamby", Linha 17-Ouro,
+"Morumbi", Linha 17-Ouro,
+"Chucri Zaidan", Linha 17-Ouro, 17, Ouro
+"Vila Cordeiro", Linha 17-Ouro, 17, Ouro
+"Campo Belo", Linha 17-Ouro, 17, Ouro
+"Vereador José Diniz", Linha 17-Ouro, 17, Ouro
+"Brooklin Paulista", Linha 17-Ouro, 17, Ouro
+"Congonhas · Jardim Aeroporto", Linha 17-Ouro, 17, Ouro
+"Vila Paulista", Linha 17-Ouro, 17, Ouro
+"Vila Babilônia", Linha 17-Ouro, 17, Ouro
+"Cidade Leonor", Linha 17-Ouro, 17, Ouro
+"Hospital Sabóia", Linha 17-Ouro, 17, Ouro
+"Jabaquara", Linha 17-Ouro, 17, Ouro


### PR DESCRIPTION
Separating line name from number and color for better data fetch when needed.

This way we can consume only a part of the data and not the whole name itself, it is more useful